### PR TITLE
Fix margin on images addressed in issue #40

### DIFF
--- a/src/css/typography.css
+++ b/src/css/typography.css
@@ -73,7 +73,6 @@ p:empty {
 ol,
 ul {
   @apply pl-6;
-  list-style-position: inside;
 }
 
 ol {

--- a/src/templates/productRoute.js
+++ b/src/templates/productRoute.js
@@ -80,7 +80,7 @@ const productRoute = ({ data, location }) => {
           <h1>{title}</h1>
           <h2>{RangeCatigoryString(range, Category)}</h2>
           <div className="text-left m-4">
-            <div className="md:float-left md:pr-4 text-center w-full md:w-1/2">
+            <div className="md:float-left mb-4 md:pr-8 text-center w-full md:w-1/2">
               {R.compose(
                 ImageComponent,
                 images


### PR DESCRIPTION
This PR fixes this issue:
https://github.com/mrhut10/futuresFineFurniture/pull/40#issuecomment-497580594
I've also reverted the list style since we have more space for the bullets in the list now that there is extra padding on the right side of the image container on `md:` screens and above.