### PR TITLE
Style product page and fix wrapping

### DIFF
--- a/src/components/BulkProducts.js
+++ b/src/components/BulkProducts.js
@@ -3,8 +3,10 @@ import propTypes from 'prop-types';
 import { ProductTile } from './ProductTile';
 
 export const BulkProducts = ({ products, heading, maxLimit }) => (
-  <div>
-    {heading ? <h4>{heading}</h4> : null}
+  <>
+    <hr />
+    <br />
+    {heading ? <h2 className="px-2 w-full">{heading}</h2> : null}
     <div className="flex flex-wrap w-full">
       {// product { name, images, slug, minPriceCents, range, variants }
       products
@@ -25,7 +27,8 @@ export const BulkProducts = ({ products, heading, maxLimit }) => (
           );
         })}
     </div>
-  </div>
+    <br />
+  </>
 );
 
 BulkProducts.propTypes = {

--- a/src/components/snipcart.js
+++ b/src/components/snipcart.js
@@ -15,7 +15,7 @@ export const BuyArea = ({ name, id, image, url, description, varients }) => {
   );
   return (
     <div className="flex flex-col">
-      <h6>{`${name}${GetProductValue ? ` \\ ${GetProductValue}` : ''}`}</h6>
+      <h6>{`${name}${GetProductValue ? ` (${GetProductValue}` : ''})`}</h6>
       {varients.length > 1 ? (
         <div className="flex items-center justify-between mb-4">
           <label htmlFor="pickVar">

--- a/src/templates/productRoute.js
+++ b/src/templates/productRoute.js
@@ -66,9 +66,12 @@ const productRoute = ({ data }) => {
         )(data)}
       />
       <Wrapper>
-        <div className="text-center">
-          <h1>{title}</h1>
-          <h2>{RangeCatigoryString(range, Category)}</h2>
+        <div className="pt-8">
+          <div className="px-4">
+            <h1>{title}</h1>
+            <h3>{RangeCatigoryString(range, Category)}</h3>
+          </div>
+          <br />
           <div className="text-left m-4">
             <div className="md:float-left mb-4 md:pr-8 text-center w-full md:w-1/2">
               {R.compose(
@@ -92,10 +95,13 @@ const productRoute = ({ data }) => {
           </div>
         </div>
       </Wrapper>
-      <div id="relatedProducts">
+      <div
+        id="relatedProducts"
+        className="flex flex-col max-w-lg mx-auto p-4 w-full"
+      >
         {
           <BulkProducts
-            heading="More Products From Range"
+            heading="More products from this range"
             maxLimit={3}
             products={data.allMarkdownRemark.edges
               .map(({ node }) => {


### PR DESCRIPTION
I fixed the heading wrapping awkwardly, I've also added a bit more whitespace, and changed to headings to be left-aligned to be more consistent with the rest of the site.

This PR also has a few design choices — feel free to reject them if:
- I wrapped the product variant in in parenthesis instead of using a backslash
- I changed the wording of the heading to 'More products from this range' from 'More Products From Range'

Hope this helps @mrhut10